### PR TITLE
Fix up tags and images

### DIFF
--- a/index.html
+++ b/index.html
@@ -413,7 +413,7 @@
 	<li><a href="http://seansimsillustration.blogspot.com/">Sean Sims</a></li>
 	<li><a href="http://www.blogboz.co.uk/">Search Optimisation Brighton</a></li>
 	<li><a href="http://www.theseasidescribbler.blogspot.com/">Seaside Scribbler</a></li>
-	<li><a href="http://www.seeninthecity.co.uk/">Seen in the City<a/></li>
+	<li><a href="http://www.seeninthecity.co.uk/">Seen in the City</a></li>
 	<li><a href="http://www.seobrighton.com">SEO Brighton ~ Affordable SEO Services</a></li>
 	<li><a href="http://seratone.blogspot.com/">Seratone</a></li>
 	<li><a href="http://www.sewrecycled.blogspot.com/">Sew Recycled!</a></li>
@@ -517,7 +517,7 @@
 	<li><a href="http://www.amyriley.blogspot.com">Typing: An Unavoidable Consequence of Bad Handwriting</a></li>
 	<li><a href="http://www.unmadeup.com/">Un-MADE-Up</a></li>
 	<li><a href="http://unistudentlife.co.uk">Uni Student Life - The UK's No.1 Student hub</a></li>
-	<li><a href="http://trulyquirkyweddingvenues.co.uk/">Unique Wedding Venue Finder</a></liftp>
+	<li><a href="http://trulyquirkyweddingvenues.co.uk/">Unique Wedding Venue Finder</a></li>
 	<li><a href="http://eldan.co.uk/diary/">Unmarked Nuclear Warheads Travel These Roads</a></li>
 	<li><a href="http://www.azureworld.blogspot.com/">Up</a></li>
 	<li><a href="http://www.vajrasatiyoga.co.uk/">Vajrasati Yoga</a></li>

--- a/styles/advanced.css
+++ b/styles/advanced.css
@@ -1,5 +1,5 @@
 body {
-	background-image: url("http://www.brightonbloggers.com/images/background.gif");
+	background-image: url("/images/background.gif");
 	margin: 5% 7%;
 }
 
@@ -7,7 +7,7 @@ body {
 	background-color: #fff;
 	color: #333;
 	border: 1px solid #345;
-	background-image: url("http://www.brightonbloggers.com/images/stones.jpg");
+	background-image: url("/images/stones.jpg");
 	background-repeat: repeat-x;
 	background-position: bottom;
 	margin: 0;
@@ -41,7 +41,7 @@ body {
 	width: 322px;
 	margin: 0;
 	padding: 0;
-	background-image: url("http://www.brightonbloggers.com/images/logo_grunge.gif");
+	background-image: url("/images/logo_grunge.gif");
 	background-repeat: no-repeat;
 	background-position: bottom left;
 }

--- a/styles/advanced.css
+++ b/styles/advanced.css
@@ -30,7 +30,6 @@ body {
 #masthead {
 	color: #fff;
 	background-color: #369;
-	background-image: url("http://www.brightonbloggers.com/includes/randomimage.php");
 	background-position: bottom right;
 	background-repeat: no-repeat;
 	height: 180px;


### PR DESCRIPTION
Noticed this:

<img width="504" alt="Screenshot 2019-08-23 at 11 24 30" src="https://user-images.githubusercontent.com/102661/63586205-bb532500-c598-11e9-9a66-b00ece04d7c2.png">

...which I think is due to some images coming from http://brightonbloggers.com so fixed them up by making the URLs relative.

Also fixed up some tags, and removed a request to a PHP script.